### PR TITLE
Support additional classes render form field

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ add it to your installed apps:
     INSTALLED_APPS = [
         '...',
         'django-spectre-css',
+        'widget_tweaks',
+
     ]
 
 ## Warning

--- a/django-spectre-css/templatetags/spectre_css.py
+++ b/django-spectre-css/templatetags/spectre_css.py
@@ -45,12 +45,14 @@ def render_form_field(field: BoundField, switch: bool = False, add_choices: choi
     }
 
 
-@register.inclusion_tag('spectre-css/render-form-field.html')
+
+@register.inclusion_tag("spectre-css/render-form-field.html")
 def render_form_field_default(field: BoundField):
-    return {
-        'field': field,
-        'field_class': 'form-input',
-    }
+    field_classes = "form-input"
+    overriden_classes = field.field.widget.attrs.get("class", "")
+    field_classes += " " + overriden_classes
+
+    return {"field": field, "field_class": field_classes}
 
 
 @register.inclusion_tag('spectre-css/render-form-checkbox.html')


### PR DESCRIPTION
first of all, thank you for supporting spectre css!

I noticed two small things, hope you'll like the PR

1/ README.md is missing info about 'widget_tweaks' being required
2/ I added support for allowing to pass some custom classes to the field. this happened to me because I wanted to add a custom date picker but I noticed that django-spectre simply ignored my overriden classes

kind regards